### PR TITLE
Feature | pass column ID to cellClassName function

### DIFF
--- a/src/columns/keyColumn.tsx
+++ b/src/columns/keyColumn.tsx
@@ -74,9 +74,9 @@ export const keyColumn = <
       : column.disabled,
   cellClassName:
     typeof column.cellClassName === 'function'
-      ? ({ rowData, rowIndex }) => {
+      ? ({ rowData, rowIndex, columnId }) => {
           return typeof column.cellClassName === 'function'
-            ? column.cellClassName({ rowData: rowData[key], rowIndex })
+            ? column.cellClassName({ rowData: rowData[key], rowIndex, columnId })
             : column.cellClassName ?? undefined
         }
       : column.cellClassName,

--- a/src/components/Row.tsx
+++ b/src/components/Row.tsx
@@ -80,7 +80,7 @@ const RowComponent = React.memo(
               className={cx(
                 !column.renderWhenScrolling && renderLight && 'dsg-cell-light',
                 typeof column.cellClassName === 'function'
-                  ? column.cellClassName({ rowData: data, rowIndex: index, columnId: column.id ?? undefined })
+                  ? column.cellClassName({ rowData: data, rowIndex: index, columnId: column.id })
                   : column.cellClassName
               )}
             >

--- a/src/components/Row.tsx
+++ b/src/components/Row.tsx
@@ -80,7 +80,7 @@ const RowComponent = React.memo(
               className={cx(
                 !column.renderWhenScrolling && renderLight && 'dsg-cell-light',
                 typeof column.cellClassName === 'function'
-                  ? column.cellClassName({ rowData: data, rowIndex: index })
+                  ? column.cellClassName({ rowData: data, rowIndex: index, columnId: column.id ?? undefined })
                   : column.cellClassName
               )}
             >

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export type Column<T, C, PasteValue> = {
   disabled: boolean | ((opt: { rowData: T; rowIndex: number }) => boolean)
   cellClassName?:
     | string
-    | ((opt: { rowData: T; rowIndex: number, columnId: string | undefined }) => string | undefined)
+    | ((opt: { rowData: T; rowIndex: number, columnId?: string }) => string | undefined)
   keepFocus: boolean
   deleteValue: (opt: { rowData: T; rowIndex: number }) => T
   copyValue: (opt: { rowData: T; rowIndex: number }) => number | string | null

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export type Column<T, C, PasteValue> = {
   disabled: boolean | ((opt: { rowData: T; rowIndex: number }) => boolean)
   cellClassName?:
     | string
-    | ((opt: { rowData: T; rowIndex: number }) => string | undefined)
+    | ((opt: { rowData: T; rowIndex: number, columnId: string | undefined }) => string | undefined)
   keepFocus: boolean
   deleteValue: (opt: { rowData: T; rowIndex: number }) => T
   copyValue: (opt: { rowData: T; rowIndex: number }) => number | string | null

--- a/website/docs/api-reference/columns.mdx
+++ b/website/docs/api-reference/columns.mdx
@@ -143,7 +143,7 @@ function App() {
 CSS class of the header cell.
 
 ### cellClassName
-> Type: `string | (({ rowData, rowIndex }) => string | undefined)`<br />
+> Type: `string | (({ rowData, rowIndex, columnId }) => string | undefined)`<br />
 > Default: `undefined`
 
 CSS class of each cell of the column. Can be a `string` if the class is the same for all cells, or a function


### PR DESCRIPTION
Hello,
thanks for the great grid component! In my current project, I could use some way to set cell style according to its value on a particular column (for example set red background when the value in the required column is missing).

That could be easily done by passing column ID to cellClassName function so className can be set to each cell individually based on this ID.

Thank you for consideration of this change,
Milan Zítka