### PR TITLE
Manage cells in error

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Feature rich:
 - Keyboard navigation and shortcuts fully-supported
 - Supports right-clicking and custom context menu
 - Supports dragging corner to expand selection
+- Highlights cells in error
 - Easy to extend and implement custom widgets
 - Blazing fast, optimized for speed, minimal renders count
 - Smooth animations
@@ -71,6 +72,54 @@ const Example = () => {
       value={data}
       onChange={setData}
       columns={columns}
+    />
+  )
+}
+```
+### Manage cell highlighting
+
+```tsx
+import {
+  DataSheetGrid,
+  checkboxColumn,
+  textColumn,
+  keyColumn,
+} from 'react-datasheet-grid'
+
+// Import the style only once in your app!
+import 'react-datasheet-grid/dist/style.css'
+import {Cell} from "./types";
+
+const Example = () => {
+  const [data, setData] = useState([
+    {active: true, firstName: 'Elon', lastName: 'Musk'},
+    {active: false, firstName: 'Jeff', lastName: 'Bezos'},
+  ])
+
+  const columns = [
+    {
+      ...keyColumn('active', checkboxColumn),
+      title: 'Active',
+    },
+    {
+      ...keyColumn('firstName', textColumn),
+      title: 'First name',
+    },
+    {
+      ...keyColumn('lastName', textColumn),
+      title: 'Last name',
+    },
+  ]
+
+  // Simply create an array of cells that are in error.
+  const errorCells: Cell[] = [{col: 0, row: 0}, {col: 0, row: 1}];
+
+  return (
+    <DataSheetGrid
+      value={data}
+      onChange={setData}
+      columns={columns}
+      errorData={errorCells} // Put your array in errorData prop.
     />
   )
 }

--- a/example/src/index.css
+++ b/example/src/index.css
@@ -1,3 +1,3 @@
 body {
-    font-family: Helvetica, sans-serif;
+  font-family: Helvetica, sans-serif;
 }

--- a/src/columns/keyColumn.tsx
+++ b/src/columns/keyColumn.tsx
@@ -76,7 +76,11 @@ export const keyColumn = <
     typeof column.cellClassName === 'function'
       ? ({ rowData, rowIndex, columnId }) => {
           return typeof column.cellClassName === 'function'
-            ? column.cellClassName({ rowData: rowData[key], rowIndex, columnId })
+            ? column.cellClassName({
+                rowData: rowData[key],
+                rowIndex,
+                columnId,
+              })
             : column.cellClassName ?? undefined
         }
       : column.cellClassName,

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -10,6 +10,7 @@ export const Cell: FC<{
   className: string
   active?: boolean
   children?: any
+  error?: boolean
 }> = ({
   children,
   gutter,
@@ -18,6 +19,7 @@ export const Cell: FC<{
   active,
   disabled,
   className,
+  error,
 }) => {
   return (
     <div
@@ -27,6 +29,7 @@ export const Cell: FC<{
         disabled && 'dsg-cell-disabled',
         gutter && active && 'dsg-cell-gutter-active',
         stickyRight && 'dsg-cell-sticky-right',
+        error && 'dsg-error-cell',
         className
       )}
       style={{

--- a/src/components/DataSheetGrid.tsx
+++ b/src/components/DataSheetGrid.tsx
@@ -49,6 +49,7 @@ import {
 import { getAllTabbableElements } from '../utils/tab'
 
 const DEFAULT_DATA: any[] = []
+const DEFAULT_ERROR_DATA: Cell[] = []
 const DEFAULT_COLUMNS: Column<any, any, any>[] = []
 const DEFAULT_CREATE_ROW: DataSheetGridProps<any>['createRow'] = () => ({})
 const DEFAULT_EMPTY_CALLBACK: () => void = () => null
@@ -67,6 +68,7 @@ export const DataSheetGrid = React.memo(
     <T extends any>(
       {
         value: data = DEFAULT_DATA,
+        errorData: error = DEFAULT_ERROR_DATA,
         className,
         style,
         height: maxHeight = 400,
@@ -854,7 +856,8 @@ export const DataSheetGrid = React.memo(
             return
           }
 
-          const rightClick = event.button === 2 || (event.button === 0 && event.ctrlKey)
+          const rightClick =
+            event.button === 2 || (event.button === 0 && event.ctrlKey)
           const clickInside =
             innerRef.current?.contains(event.target as Node) || false
 
@@ -1611,6 +1614,7 @@ export const DataSheetGrid = React.memo(
 
       const itemData = useMemoObject<ListItemData<T>>({
         data,
+        errorData: error,
         contentWidth: fullWidth ? undefined : contentWidth,
         columns,
         hasStickyRightColumn,

--- a/src/components/Row.tsx
+++ b/src/components/Row.tsx
@@ -1,5 +1,5 @@
 import { areEqual, ListChildComponentProps } from 'react-window'
-import { ListItemData, RowProps } from '../types'
+import { Cell as CellType, ListItemData, RowProps } from '../types'
 import React, { useCallback } from 'react'
 import cx from 'classnames'
 import { Cell } from './Cell'
@@ -12,6 +12,7 @@ const RowComponent = React.memo(
     index,
     style,
     data,
+    errorData,
     isScrolling,
     columns,
     hasStickyRightColumn,
@@ -69,6 +70,9 @@ const RowComponent = React.memo(
             (typeof column.disabled === 'function' &&
               column.disabled({ rowData: data, rowIndex: index }))
 
+          const isCellInError = errorData?.find(
+            (cell: CellType) => cell.col === i - 1 && cell.row === index
+          )
           return (
             <Cell
               key={i}
@@ -80,9 +84,14 @@ const RowComponent = React.memo(
               className={cx(
                 !column.renderWhenScrolling && renderLight && 'dsg-cell-light',
                 typeof column.cellClassName === 'function'
-                  ? column.cellClassName({ rowData: data, rowIndex: index, columnId: column.id })
+                  ? column.cellClassName({
+                      rowData: data,
+                      rowIndex: index,
+                      columnId: column.id,
+                    })
                   : column.cellClassName
               )}
+              error={!!isCellInError}
             >
               {(column.renderWhenScrolling || !renderLight) && (
                 <Component
@@ -137,6 +146,7 @@ export const Row = <T extends any>({
     <RowComponent
       index={index - 1}
       data={data.data[index - 1]}
+      errorData={data.errorData}
       columns={data.columns}
       style={{
         ...style,

--- a/src/style.css
+++ b/src/style.css
@@ -15,6 +15,7 @@
   --dsg-expand-rows-indicator-width: 10px;
   --dsg-scroll-shadow-width: 7px;
   --dsg-scroll-shadow-color: rgba(0, 0, 0, 0.2);
+  --dsg-error-background-cell-color: rgba(255, 69, 69, 0.5);
 }
 
 .dsg-container {
@@ -58,6 +59,10 @@
   border-right: none;
   box-shadow: 1px 1px var(--dsg-border-color);
   position: relative;
+}
+
+.dsg-error-cell {
+  background-color: var(--dsg-error-background-cell-color);
 }
 
 .dsg-hidden-cell {

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,11 @@ export type Column<T, C, PasteValue> = {
   disabled: boolean | ((opt: { rowData: T; rowIndex: number }) => boolean)
   cellClassName?:
     | string
-    | ((opt: { rowData: T; rowIndex: number, columnId?: string }) => string | undefined)
+    | ((opt: {
+        rowData: T
+        rowIndex: number
+        columnId?: string
+      }) => string | undefined)
   keepFocus: boolean
   deleteValue: (opt: { rowData: T; rowIndex: number }) => T
   copyValue: (opt: { rowData: T; rowIndex: number }) => number | string | null
@@ -52,6 +56,7 @@ export type Column<T, C, PasteValue> = {
 
 export type ListItemData<T> = {
   data: T[]
+  errorData: Cell[]
   contentWidth?: number
   columns: Column<T, any, string>[]
   hasStickyRightColumn: boolean
@@ -100,6 +105,7 @@ export type SelectionContextType = {
 export type RowProps<T> = {
   index: number
   data: T
+  errorData?: Cell[]
   style: React.CSSProperties
   isScrolling?: boolean
   columns: Column<T, any, string>[]
@@ -157,6 +163,7 @@ export type Operation = {
 
 export type DataSheetGridProps<T> = {
   value?: T[]
+  errorData?: Cell[]
   style?: React.CSSProperties
   className?: string
   rowClassName?:


### PR DESCRIPTION
 Highlights cells that are in errors, from an array passed in DataSheetGrid props.

I added this for my use case :
1) I integrate my data to the grid
2) I click on an "Import" button
3) The back-end check for errors, then return cells that are in errors 
4) I highlight my cells with this prop.
