### PR TITLE
Support yyyy.mm.dd format, enter year under 10000

### DIFF
--- a/src/columns/dateColumn.tsx
+++ b/src/columns/dateColumn.tsx
@@ -21,6 +21,7 @@ const DateComponent = React.memo<CellProps<Date | null, any>>(
         type="date"
         // Important to prevent any undesired "tabbing"
         tabIndex={-1}
+        max="9999-12-31"
         ref={ref}
         // The `pointerEvents` trick is the same than in `textColumn`
         // Only show the calendar symbol on non-empty cells, or when cell is active, otherwise set opacity to 0
@@ -50,7 +51,7 @@ export const dateColumn: Partial<Column<Date | null, any, string>> = {
     rowData ? rowData.toISOString().substr(0, 10) : null,
   // Because the Date constructor works using iso format, we can use it to parse ISO string back to a Date object
   pasteValue: ({ value }) => {
-    const date = new Date(value.replace(/\.\s|\//g, '-'))
+    const date = new Date(value.replace(/\.\s?|\//g, '-'))
     return isNaN(date.getTime()) ? null : date
   },
   minWidth: 170,

--- a/src/columns/isoDateColumn.tsx
+++ b/src/columns/isoDateColumn.tsx
@@ -21,6 +21,7 @@ const IsoDateComponent = React.memo<CellProps<string | null, any>>(
         type="date"
         // Important to prevent any undesired "tabbing"
         tabIndex={-1}
+        max="9999-12-31"
         ref={ref}
         // The `pointerEvents` trick is the same than in `textColumn`
         // Only show the calendar symbol on non-empty cells, or when cell is active, otherwise set opacity to 0
@@ -49,7 +50,7 @@ export const isoDateColumn: Partial<Column<string | null, any, string>> = {
   deleteValue: () => null,
   // Because the Date constructor works using iso format, we can use it to parse ISO string back to a Date object
   pasteValue: ({ value }) => {
-    const date = new Date(value.replace(/\.\s|\//g, '-'))
+    const date = new Date(value.replace(/\.\s?|\//g, '-'))
     return isNaN(date.getTime()) ? null : date.toISOString().substr(0, 10)
   },
   minWidth: 170,


### PR DESCRIPTION
* Support yyyy.mm.dd format
* When entering a date, prevent entering the years 10000 to 100000.

https://user-images.githubusercontent.com/30230285/209544728-98b6e1f4-3001-46df-bc71-596d27a892c6.mov

