### PR TITLE
Improved to switch to Edit mode when entering non-English characters in Cell

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -6,7 +6,7 @@ import {
   keyColumn,
   textColumn,
 } from '../../src'
-import '../../dist/style.css'
+import '../../src/style.css'
 
 type Row = {
   active: boolean

--- a/src/components/DataSheetGrid.tsx
+++ b/src/components/DataSheetGrid.tsx
@@ -1416,7 +1416,7 @@ export const DataSheetGrid = React.memo(
             )
             event.preventDefault()
           } else if (
-            event.key.match(/^[ -~]$/) &&
+            (event.key.match(/^[ -~]$/) || event.code.match(/Key[A-Z]$/)) &&
             !event.ctrlKey &&
             !event.metaKey &&
             !event.altKey

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -83,7 +83,6 @@ export const Grid = <T extends any>({
       }
       return index
     },
-    enableSmoothScroll: false,
     overscan: 5,
   })
 
@@ -93,7 +92,6 @@ export const Grid = <T extends any>({
     estimateSize: (index) => columnWidths?.[index] ?? 100,
     horizontal: true,
     getItemKey: (index: number): React.Key => columns[index].id ?? index,
-    enableSmoothScroll: false,
     overscan: 1,
     rangeExtractor: (range) => {
       const result = defaultRangeExtractor(range)


### PR DESCRIPTION
1. Improved to switch to Edit mode when entering non-English characters in Cell (e.g Korean)
2. Fixed the problem of incorrectly referencing css in the example code
3. Remove unused property from virtualizer library (enableSmoothScroll)