### PR TITLE
Fix internationalization on user input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-datasheet-grid",
-  "version": "4.9.3",
+  "version": "4.9.4",
   "description": "An Excel-like React component to create beautiful spreadsheets.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/columns/floatColumn.tsx
+++ b/src/columns/floatColumn.tsx
@@ -1,3 +1,4 @@
+import { parseFloatIntl } from '../utils/internationalization'
 import { createTextColumn } from './textColumn'
 
 export const floatColumn = createTextColumn<number | null>({
@@ -5,11 +6,11 @@ export const floatColumn = createTextColumn<number | null>({
   formatBlurredInput: (value) =>
     typeof value === 'number' ? new Intl.NumberFormat().format(value) : '',
   parseUserInput: (value) => {
-    const number = parseFloat(value)
+    const number = parseFloatIntl(value)
     return !isNaN(number) ? number : null
   },
   parsePastedValue: (value) => {
-    const number = parseFloat(value)
+    const number = parseFloatIntl(value)
     return !isNaN(number) ? number : null
   },
 })

--- a/src/columns/intColumn.tsx
+++ b/src/columns/intColumn.tsx
@@ -1,3 +1,4 @@
+import { parseFloatIntl } from '../utils/internationalization'
 import { createTextColumn } from './textColumn'
 
 export const intColumn = createTextColumn<number | null>({
@@ -5,11 +6,11 @@ export const intColumn = createTextColumn<number | null>({
   formatBlurredInput: (value) =>
     typeof value === 'number' ? new Intl.NumberFormat().format(value) : '',
   parseUserInput: (value) => {
-    const number = parseFloat(value)
+    const number = parseFloatIntl(value)
     return !isNaN(number) ? Math.round(number) : null
   },
   parsePastedValue: (value) => {
-    const number = parseFloat(value)
+    const number = parseFloatIntl(value)
     return !isNaN(number) ? Math.round(number) : null
   },
 })

--- a/src/columns/percentColumn.tsx
+++ b/src/columns/percentColumn.tsx
@@ -1,3 +1,4 @@
+import { parseFloatIntl } from '../utils/internationalization'
 import { createTextColumn } from './textColumn'
 
 const TEN_TO_THE_12 = 1000000000000
@@ -17,11 +18,11 @@ export const percentColumn = createTextColumn<number | null>({
       ? String(Math.round(value * TEN_TO_THE_12) / TEN_TO_THE_10)
       : '',
   parseUserInput: (value) => {
-    const number = parseFloat(value)
+    const number = parseFloatIntl(value)
     return !isNaN(number) ? number / 100 : null
   },
   parsePastedValue: (value) => {
-    const number = parseFloat(value)
+    const number = parseFloatIntl(value)
     return !isNaN(number) ? number : null
   },
 })

--- a/src/utils/internationalization.test.ts
+++ b/src/utils/internationalization.test.ts
@@ -1,0 +1,55 @@
+import { parseFloatIntl } from './internationalization'
+
+const NARROW_NO_BREAK_SPACE = ' '
+const NO_BREAK_SPACE = ' '
+
+describe('parsePlainTextData', () => {
+  test('Parse standard english number', () => {
+    expect(parseFloatIntl('1,234.56', 'en')).toEqual(1234.56)
+  })
+  test('Parse awkward english number', () => {
+    expect(parseFloatIntl('44,44,44.44', 'en')).toEqual(444444.44)
+  })
+
+  test('Parse standard german number', () => {
+    expect(parseFloatIntl('1.234,56', 'de')).toEqual(1234.56)
+  })
+  test('Parse awkward german number', () => {
+    expect(parseFloatIntl('44.44.44,44', 'de')).toEqual(444444.44)
+  })
+
+  test('Parse standard french number', () => {
+    expect(
+      parseFloatIntl(`1${NARROW_NO_BREAK_SPACE}234,56`, 'fr')
+    ).toEqual(1234.56)
+  })
+  test('Parse awkward french number', () => {
+    expect(
+      parseFloatIntl(
+        `44${NARROW_NO_BREAK_SPACE}44${NARROW_NO_BREAK_SPACE}44,44`,
+        'fr'
+      )
+    ).toEqual(444444.44)
+  })
+
+  test('Parse standard polish number', () => {
+    expect(
+      parseFloatIntl(`1${NO_BREAK_SPACE}234,56`, 'pl')
+    ).toEqual(1234.56)
+  })
+  test('Parse awkward polish number', () => {
+    expect(
+      parseFloatIntl(
+        `44${NO_BREAK_SPACE}44${NO_BREAK_SPACE}44,44`,
+        'pl'
+      )
+    ).toEqual(444444.44)
+  })
+
+  test('Parse standard spanish number', () => {
+    expect(parseFloatIntl('1.234,56', 'es')).toEqual(1234.56)
+  })
+  test('Parse awkward spanish number', () => {
+    expect(parseFloatIntl('44.44.44,44', 'es')).toEqual(444444.44)
+  })
+})

--- a/src/utils/internationalization.ts
+++ b/src/utils/internationalization.ts
@@ -1,0 +1,19 @@
+// For more information on how this works, check out this blogpost
+// https://observablehq.com/@mbostock/localized-number-parsing
+export const parseFloatIntl = (
+  float: string,
+  locale?: string
+): number => {
+  const parts = new Intl.NumberFormat(locale).formatToParts(12345.6)
+  // Non null assertions since there will always be group + decimal parts in 12345.6
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const groupValue = parts.find((d) => d.type === 'group')!.value
+  const group = new RegExp(`[${groupValue}]`, 'g')
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const decimalValue = parts.find((d) => d.type === 'decimal')!.value
+  const decimal = new RegExp(`[${decimalValue}]`)
+
+  const val = float.trim().replace(group, '').replace(decimal, '.')
+
+  return parseFloat(val)
+}


### PR DESCRIPTION
Internationalization of user input doesn't work, users must type only in the format that `parseFloat` accepts which is the standard English thousand (`,`) and decimal (`.`) separators.

An example of what goes wrong:

German user sees table values respecting the separation system (i.e thousand separator in `.` and decimal seperator in `,`). This is good, but then he types in a new value `5.000,5` (five thousand point five), but `parseFloat` will return `5`!

This is confusing since the table displays the values in the correct form, but you must type in values using the standard English form.