### PR TITLE
fix issues when pasting multiple cells with quoted text and new lines

### DIFF
--- a/src/utils/copyPasting.test.ts
+++ b/src/utils/copyPasting.test.ts
@@ -138,6 +138,23 @@ describe('parsePlainTextData', () => {
     expect(parseTextPlainData('"foo\nbar""baz"""')).toEqual([['foo\nbar"baz"']])
   })
 
+  test('single cell multi line clean', () => {
+    expect(parseTextPlainData('"foo\nbar"')).toEqual([['foo\nbar']])
+  })
+
+  test('multi cell multi line', () => {
+    expect(parseTextPlainData('"foo\nbar"\n"baz\nqux"')).toEqual([
+      ['foo\nbar'],
+      ['baz\nqux'],
+    ])
+  })
+
+  test('multi cell single line', () => {
+    expect(parseTextPlainData('"foo\nbar"\t"baz\nqux"')).toEqual([
+      ['foo\nbar', 'baz\nqux'],
+    ])
+  })
+
   test('quoted first cell', () => {
     expect(parseTextPlainData('"foo\nbar')).toEqual([['"foo'], ['bar']])
   })

--- a/src/utils/copyPasting.ts
+++ b/src/utils/copyPasting.ts
@@ -38,9 +38,13 @@ export const parseTextPlainData = (data: string): string[][] => {
 
   const saveCell = () => {
     let str = cleanData.slice(startCell, cursor)
+    if (str[0] === '"' && str[str.length - 1] === '"') {
+      quoted = true
+    }
 
     if (quoted && str[str.length - 1] === '"' && str.includes('\n')) {
       str = str.slice(1, str.length - 1).replace(/""/g, '"')
+      quoted = false
     }
 
     if (quoted && str[str.length - 1] !== '"') {


### PR DESCRIPTION
Ran into a few bugs while pasting text with new lines in it. It's a little bit of a wonky fix because `quoted` gets flipped to false, since there is more text, but when we save the cell, since it's false, the quotes stay when they shouldn't. If you can think of an easier way to accomplish this, i'm all for it, but doing the double check right before save seemed like a good fix.

```
// e.g.

"Test\ntest" would give me [['Test'], ['test']]

and

"Test\ntest"\n"Hello" would give me [['"Test\ntest"'], ['Hello']]
```

