### PR TITLE
fix: Also include other language characters to trigger cell focus

### DIFF
--- a/src/components/DataSheetGrid.tsx
+++ b/src/components/DataSheetGrid.tsx
@@ -1456,7 +1456,7 @@ export const DataSheetGrid = React.memo(
             )
             event.preventDefault()
           } else if (
-            (event.key.match(/^[ -~]$/) || event.code.match(/Key[A-Z]$/)) &&
+            (event.key.match(/^[ -~]$/) || event.code.match(/Key[A-Z\p{L}]$/u)) &&
             !event.ctrlKey &&
             !event.metaKey &&
             !event.altKey


### PR DESCRIPTION
When a cell is active, library wants a character key press to trigger focus to that cell so the user can immediately start typing.

Right now this does not work for non-ASCII characters.

This pr changes the relevant regex to also include other characters from other languages, like ğ ö ç ş etc.