### PR TITLE
Context Menu Paste issue fixed.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-datasheet-grid",
-  "version": "4.11.0",
+  "version": "4.11.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-datasheet-grid",
-      "version": "4.11.0",
+      "version": "4.11.2",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-virtual": "^3.0.0-beta.18",

--- a/src/components/DataSheetGrid.tsx
+++ b/src/components/DataSheetGrid.tsx
@@ -1564,8 +1564,7 @@ export const DataSheetGrid = React.memo(
                     if (item.types.includes('text/html')) {
                       const htmlTextData = await item.getType('text/html')
                       pasteData = parseTextHtmlData(await htmlTextData.text())
-                    }
-                    else if (item.types.includes('text/plain')) {
+                    } else if (item.types.includes('text/plain')) {
                       const plainTextData = await item.getType('text/plain')
                       pasteData = parseTextPlainData(await plainTextData.text())
                     } else if (item.types.includes('text')) {

--- a/src/components/DataSheetGrid.tsx
+++ b/src/components/DataSheetGrid.tsx
@@ -1561,12 +1561,13 @@ export const DataSheetGrid = React.memo(
                   const items = await navigator.clipboard.read()
                   items.forEach(async (item) => {
                     let pasteData = [['']]
-                    if (item.types.includes('text/plain')) {
-                      const plainTextData = await item.getType('text/plain')
-                      pasteData = parseTextPlainData(await plainTextData.text())
-                    } else if (item.types.includes('text/html')) {
+                    if (item.types.includes('text/html')) {
                       const htmlTextData = await item.getType('text/html')
                       pasteData = parseTextHtmlData(await htmlTextData.text())
+                    }
+                    else if (item.types.includes('text/plain')) {
+                      const plainTextData = await item.getType('text/plain')
+                      pasteData = parseTextPlainData(await plainTextData.text())
                     } else if (item.types.includes('text')) {
                       const htmlTextData = await item.getType('text')
                       pasteData = parseTextHtmlData(await htmlTextData.text())


### PR DESCRIPTION
Problem: When copying from an excel sheet where cell has multiple lines the context menu paste does not work.

There are 2 ways you can paste:
Keyboard: cntrl+v (OnPaste)
Context Menu: right click paste (Type: 'PASTE')

Keyboard first checks
```
if (item.types.includes('text/html')) {
                      const htmlTextData = await item.getType('text/html')
                      pasteData = parseTextHtmlData(await htmlTextData.text())
}
```

Whereas the context menu paste was first checking:
```
if (item.types.includes('text/plain')) {
                      const plainTextData = await item.getType('text/plain')
                      pasteData = parseTextPlainData(await plainTextData.text())
 }
```

With my changes 'text/html' is checked first on context menu paste just like it already is on keybaord paste.

Here is a gif showing the issue when a cell has **multiple lines** context menu paste does not work:

![CleanShot 2024-01-17 at 10  06 20](https://github.com/nick-keller/react-datasheet-grid/assets/109949748/1b7ab55c-c6bd-4b4e-999d-8817ef94395c)

Issue is fixed with my changes 🙂