### PR TITLE
fix: non-ASCII characters at cell focus and tests

### DIFF
--- a/src/components/DataSheetGrid.tsx
+++ b/src/components/DataSheetGrid.tsx
@@ -28,6 +28,7 @@ import deepEqual from 'fast-deep-equal'
 import { ContextMenu } from './ContextMenu'
 import {
   encodeHtml,
+  isPrintableUnicode,
   parseTextHtmlData,
   parseTextPlainData,
 } from '../utils/copyPasting'
@@ -1456,7 +1457,7 @@ export const DataSheetGrid = React.memo(
             )
             event.preventDefault()
           } else if (
-            (event.key.match(/^[ -~]$/) || event.code.match(/Key[A-Z\p{L}]$/u)) &&
+            (isPrintableUnicode(event.key) || event.code.match(/Key[A-Z]$/)) &&
             !event.ctrlKey &&
             !event.metaKey &&
             !event.altKey

--- a/src/utils/copyPasting.test.ts
+++ b/src/utils/copyPasting.test.ts
@@ -2,6 +2,7 @@ import {
   parseTextPlainData,
   parseTextHtmlData,
   encodeHtml,
+  isPrintableUnicode,
 } from './copyPasting'
 import { JSDOM } from 'jsdom'
 
@@ -156,4 +157,24 @@ test('encodeHtml', () => {
   expect(encodeHtml('<div title="foo\'bar">baz</div>')).toBe(
     '&lt;div title=&quot;foo&#039;bar&quot;&gt;baz&lt;/div&gt;'
   )
+})
+
+test('isPrintableUnicode', () => {
+  expect(isPrintableUnicode('a')).toBe(true)
+  expect(isPrintableUnicode('ş')).toBe(true)
+  expect(isPrintableUnicode('Ğ')).toBe(true)
+  expect(isPrintableUnicode('中')).toBe(true)
+  expect(isPrintableUnicode('©')).toBe(true)
+  expect(isPrintableUnicode('5')).toBe(true)
+  expect(isPrintableUnicode('!')).toBe(true)
+  expect(isPrintableUnicode('.')).toBe(true)
+  expect(isPrintableUnicode(':')).toBe(true)
+  expect(isPrintableUnicode('[')).toBe(true)
+  expect(isPrintableUnicode('\x0B')).toBe(false) // Vertical Tab
+  expect(isPrintableUnicode('\x7F')).toBe(false) // Delete
+  expect(isPrintableUnicode('\r')).toBe(false)
+  expect(isPrintableUnicode(' ')).toBe(false)
+  expect(isPrintableUnicode('\t')).toBe(false)
+  expect(isPrintableUnicode('\n')).toBe(false)
+  expect(isPrintableUnicode('\x90')).toBe(false) // Non-printable character in the extended ASCII range
 })

--- a/src/utils/copyPasting.ts
+++ b/src/utils/copyPasting.ts
@@ -103,3 +103,7 @@ export const encodeHtml = (str: string) => {
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#039;')
 }
+
+export const isPrintableUnicode = (str: string): boolean => {
+  return str.match(/^[^\x00-\x20\x7F-\x9F]$/) !== null
+}

--- a/tests/editTextCell.test.tsx
+++ b/tests/editTextCell.test.tsx
@@ -116,6 +116,26 @@ test('Enter to edit', () => {
   })
 })
 
+test('Non-ascii character to edit', () => {
+  const ref = { current: null as unknown as DataSheetGridRef }
+  const data = {
+    current: [
+      { firstName: 'Elon', lastName: 'Musk' },
+      { firstName: 'Jeff', lastName: 'Bezos' },
+    ],
+  }
+
+  render(<DataWrapper dataRef={data} dsgRef={ref} columns={columns} />)
+
+  act(() => ref.current.setActiveCell({ col: 0, row: 1 }))
+
+  userEvent.keyboard('ş')
+  expect(data.current).toEqual([
+    { firstName: 'Elon', lastName: 'Musk' },
+    { firstName: 'ş', lastName: 'Bezos' },
+  ])
+})
+
 test('Lazy cell validate with Enter', () => {
   const ref = { current: null as unknown as DataSheetGridRef }
   const data = {


### PR DESCRIPTION
Sorry for the previous mistake https://github.com/nick-keller/react-datasheet-grid/pull/330, turns out JS keyboard events work like this:

`{
 "key": "ş",
 "keyCode": 186,
 "which": 186,
 "code": "Semicolon",
 "location": 0,
 "altKey": false,
 "ctrlKey": false,
 "metaKey": false,
 "shiftKey": false,
 "repeat": false
}`

So we need to check the "key" instead of "code".

Fixed and added tests.