### PR TITLE
Fix an error when pasting from .xls file

### DIFF
--- a/src/columns/textColumn.tsx
+++ b/src/columns/textColumn.tsx
@@ -175,7 +175,7 @@ export function createTextColumn<T = string | null>({
   formatInputOnFocus = (value) => String(value ?? ''),
   formatForCopy = (value) => String(value ?? ''),
   parsePastedValue = (value) =>
-    (value.replace(/[\n\r]+/g, ' ').trim() || (null as unknown)) as T,
+    ((value.replace(/[\n\r]+/g, ' ') ?? '').trim() || (null as unknown)) as T,
 }: TextColumnOptions<T> = {}): Partial<Column<T, TextColumnData<T>, string>> {
   return {
     component: TextComponent as unknown as CellComponent<T, TextColumnData<T>>,


### PR DESCRIPTION
This fixes #267 


this error happens when pasting value from `.xls` file (`.xlsx` is fine)

![image](https://github.com/nick-keller/react-datasheet-grid/assets/80534651/af3783ab-a914-46a9-8120-e15c30a6a0bf)

